### PR TITLE
Fix README naming. Add eu-west-2 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Cloudformation will create the following resources as part of the AMI Builder fo
 Region | AMI Builder Launch Template
 ------------------------------------------------- | ---------------------------------------------------------------------------------
 N. Virginia (us-east-1) | [![Launch Stack](images/deploy-to-aws.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=AMI-Builder-Blogpost&templateURL=https://s3-eu-west-1.amazonaws.com/ami-builder-packer/cloudformation/pipeline.yaml)
-N. Virginia (eu-west-1) | [![Launch Stack](images/deploy-to-aws.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/new?stackName=AMI-Builder-Blogpost&templateURL=https://s3-eu-west-1.amazonaws.com/ami-builder-packer/cloudformation/pipeline.yaml)
+Ireland (eu-west-1) | [![Launch Stack](images/deploy-to-aws.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/new?stackName=AMI-Builder-Blogpost&templateURL=https://s3-eu-west-1.amazonaws.com/ami-builder-packer/cloudformation/pipeline.yaml)
+London (eu-west-2) | [![Launch Stack](images/deploy-to-aws.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/new?stackName=AMI-Builder-Blogpost&templateURL=https://s3-eu-west-1.amazonaws.com/ami-builder-packer/cloudformation/pipeline.yaml)
 
 **To clone the AWS CodeCommit repository (console)**
 


### PR DESCRIPTION
This PR does two things:

- fixes a typo in the README, which called eu-west-1 out as being in N. Virginia
- adds support for eu-west-2 (London) in the README