### PR TITLE
Fix #3 due to Ansible Role breaking changes and updates Packer

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -7,10 +7,11 @@
     # CIS Controls whitepaper:  http://bit.ly/2mGAmUc
     # AWS CIS Whitepaper:       http://bit.ly/2m2Ovrh
     cis_level_1_exclusions:
-    # 3.4.2 and 3.4.3 effectively blocks access to all ports to the machine
+    # 3.4.2, 3.4.3 and 3.6.2 effectively blocks access to all ports to the machine
     ## This can break automation; ignoring it as there are stronger mechanisms than that
       - 3.4.2 
       - 3.4.3
+      - 3.6.2
     # Cloudwatch Logs will be used instead of Rsyslog/Syslog-ng
     ## Same would be true if any other software that doesn't support Rsyslog/Syslog-ng mechanisms
       - 4.2.1.4
@@ -18,6 +19,8 @@
       - 4.2.2.5
     # Autofs is no longer installed and we need to ignore it or else will fail
       - 1.1.19
+    # Password reuse limit task fails due to AttributionError in Ansible code; skipping
+      - 5.3.3
     # Cloudwatch Logs Role configuration
     logs:
       - file: /var/log/messages

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   pre_build:
     commands:
       - echo "Installing Packer"
-      - curl -o packer.zip https://releases.hashicorp.com/packer/1.0.3/packer_1.0.3_linux_amd64.zip && unzip packer.zip
+      - curl -o packer.zip https://releases.hashicorp.com/packer/1.2.2/packer_1.2.2_linux_amd64.zip && unzip packer.zip
       - echo "Validating Packer template"
       - ./packer validate packer_cis.json
   build:


### PR DESCRIPTION
Issue #3 , if available: `Build failing post build_phase`

Description of changes:

3rd party CIS Ansible Role has been recently updated and contained some breaking changes such as 3.6.2 and 5.3.3 that drops INPUT traffic and causes AttributeError errors in Ansible file handling.

Therefore, this **PR**:

* Skips both tasks as build succeeds in 10 out of 10 attempts after skipping those
* Unrelated but important, it also updates Packer to **1.2.2** to make sure it covers some bugfixes reported at [Packer Changelog](https://github.com/hashicorp/packer/blob/master/CHANGELOG.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.