### PR TITLE
Update packer_cis.json file

### DIFF
--- a/packer_cis.json
+++ b/packer_cis.json
@@ -44,7 +44,7 @@
   "provisioners": [{
       "type": "shell",
       "inline": [
-        "sudo pip install ansible"
+        "sudo pip install ansible==2.7.9"
       ]
     },
     {


### PR DESCRIPTION
Fixing the issue raised from ansible 2.8.0  https://github.com/ansible/ansible/issues/56583 by pining Ansible version to 2.7.9

*Issue #, if available:*
https://github.com/ansible/ansible/issues/56583

*Description of changes:*
Pinning the version of Ansible to 2.7.9 to prevent below error
AWS AMI Builder - CIS: ·[0;31mfatal: [127.0.0.1]: FAILED! => {"changed": false, "cmd": "dnf install -y python2-dnf", "msg": "[Errno 2] No such file or directory", "rc": 2}·[0m 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
